### PR TITLE
Make starship better than native with Left and Right prompts!

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ If you're using Starship for both for another shell and for xonsh and you want t
 You can set the different starship configs for left and right parts of prompt:
 
 ```python
-$XONTRIB_PROMPT_STARSHIP_LEFT  = "~/.config/starship_xonsh_left.toml"
-$XONTRIB_PROMPT_STARSHIP_RIGHT = "~/.config/starship_xonsh_right.toml"
+$XONTRIB_PROMPT_STARSHIP_LEFT_CONFIG  = "~/.config/starship_xonsh_left.toml"
+$XONTRIB_PROMPT_STARSHIP_RIGHT_CONFIG = "~/.config/starship_xonsh_right.toml"
 xontrib load prompt_starship
 ```
+
+## Known issues
+
+In case of using left and right prompt with more than one line the result could have issues. The case with more than one line not properly tested.
 
 ## Credits
 * This package is the part of [ergopack](https://github.com/anki-code/xontrib-ergopack) - the pack of ergonomic xontribs.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ xpip install xontrib-prompt-starship
 xontrib load prompt_starship
 ```
 
+To split the prompt into __two parts__ specify the __full path__ (including the file name) of the respective left/right prompt configuration files in the respective `$XONTRIB_PROMPT_STARSHIP_LEFT`/`XONTRIB_PROMPT_STARSHIP_RIGHT` environment variables in your profile, for example:
+
+```sh
+from os import path
+_home = path.expanduser("~") # to make it work across different OS
+$XONTRIB_PROMPT_STARSHIP_LEFT  = path.join(_home, ".config/starship/starship_left.toml")
+$XONTRIB_PROMPT_STARSHIP_RIGHT = path.join(_home, ".config/starship/starship_right.toml")
+```
+
 ## Recommendation
 
 We suggest to use `@` character to remember about you're using xonsh syntax and to potentially spread the word about xonsh if you make a screenshot or show your terminal to friends or collegues. Add this to your `~/.config/starship.toml`:

--- a/README.md
+++ b/README.md
@@ -22,15 +22,6 @@ xpip install xontrib-prompt-starship
 xontrib load prompt_starship
 ```
 
-To split the prompt into __two parts__ specify the __full path__ (including the file name) of the respective left/right prompt configuration files in the respective `$XONTRIB_PROMPT_STARSHIP_LEFT`/`XONTRIB_PROMPT_STARSHIP_RIGHT` environment variables in your profile, for example:
-
-```sh
-from os import path
-_home = path.expanduser("~") # to make it work across different OS
-$XONTRIB_PROMPT_STARSHIP_LEFT  = path.join(_home, ".config/starship/starship_left.toml")
-$XONTRIB_PROMPT_STARSHIP_RIGHT = path.join(_home, ".config/starship/starship_right.toml")
-```
-
 ## Recommendation
 
 We suggest to use `@` character to remember about you're using xonsh syntax and to potentially spread the word about xonsh if you make a screenshot or show your terminal to friends or collegues. Add this to your `~/.config/starship.toml`:
@@ -40,6 +31,16 @@ success_symbol = "[@](bold green)"
 error_symbol = "[@](bold red)"
 ```
 If you're using Starship for both for another shell and for xonsh and you want to have different characters you can just put the lines above to the new `~/.config/starship_xonsh.toml` file. Then you should add to the `~/.xonshrc` file the line `$STARSHIP_CONFIG = '~/.config/starship_xonsh.toml'` before `xontrib load prompt_starship`.
+
+## Configuration
+
+You can set the different starship configs for left and right parts of prompt:
+
+```python
+$XONTRIB_PROMPT_STARSHIP_LEFT  = "~/.config/starship_xonsh_left.toml"
+$XONTRIB_PROMPT_STARSHIP_RIGHT = "~/.config/starship_xonsh_right.toml"
+xontrib load prompt_starship
+```
 
 ## Credits
 * This package is the part of [ergopack](https://github.com/anki-code/xontrib-ergopack) - the pack of ergonomic xontribs.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (IOError, OSError):
 
 setuptools.setup(
     name='xontrib-prompt-starship',
-    version='0.0.5',
+    version='0.1.0',
     license='MIT',
     author='anki-code',
     author_email='no@no.no',

--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -7,14 +7,13 @@ __xonsh__.env['STARSHIP_SESSION_KEY'] = __xonsh__.subproc_captured_stdout(['star
 
 
 def _starship_prompt(cfg=None):
-    cmd = [
+    with __xonsh__.env.swap({'STARSHIP_CONFIG': cfg} if cfg else {}):
+        return __xonsh__.subproc_captured_stdout([
         'starship', 'prompt',
         '--status', str(int( __xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0',
         '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
         '--jobs', str(len(__xonsh__.all_jobs))
-    ]
-    with __xonsh__.env.swap({'STARSHIP_CONFIG': cfg} if cfg else {}):
-        return __xonsh__.subproc_captured_stdout(cmd)
+    ])
 
         
 _left_cfg  = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_LEFT' , '')

--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -9,11 +9,11 @@ __xonsh__.env['STARSHIP_SESSION_KEY'] = __xonsh__.subproc_captured_stdout(['star
 def _starship_prompt(cfg=None):
     with __xonsh__.env.swap({'STARSHIP_CONFIG': cfg} if cfg else {}):
         return __xonsh__.subproc_captured_stdout([
-        'starship', 'prompt',
-        '--status', str(int( __xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0',
-        '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
-        '--jobs', str(len(__xonsh__.all_jobs))
-    ])
+            'starship', 'prompt',
+            '--status', str(int( __xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0',
+            '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
+            '--jobs', str(len(__xonsh__.all_jobs))
+        ])
 
         
 _left_cfg  = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_LEFT' , '')

--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -1,8 +1,31 @@
+from os import path
+
+_starship_cfg_left  = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_LEFT' , '')
+_starship_cfg_right = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_RIGHT', '')
+
 __xonsh__.env['STARSHIP_SHELL'] = 'sh'  # Fix https://github.com/anki-code/xontrib-prompt-starship/issues/1
 __xonsh__.env['STARSHIP_SESSION_KEY'] = __xonsh__.subproc_captured_stdout(['starship','session']).strip()
-__xonsh__.env['PROMPT'] = lambda: __xonsh__.subproc_captured_stdout([
+
+def _starship_prompt():
+  return __xonsh__.subproc_captured_stdout([
     'starship', 'prompt',
-    '--status', str(int(__xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0',
-    '--cmd-duration', str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
+    '--status'       , str(int( __xonsh__.history[-1].rtn))\
+      if len(__xonsh__.history) > 0 else '0',
+    '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000))\
+      if len(__xonsh__.history) > 0 else '0',
     '--jobs', str(len(__xonsh__.all_jobs))
-])
+    ])
+
+def _starship_prompt_left():
+  if _starship_cfg_left:
+    with __xonsh__.env.swap(STARSHIP_CONFIG=_starship_cfg_left):
+      return _starship_prompt()
+  else:
+    return _starship_prompt()
+__xonsh__.env['PROMPT']	= _starship_prompt_left
+
+if path.exists(_starship_cfg_right):
+  def _starship_prompt_right():
+    with __xonsh__.env.swap(STARSHIP_CONFIG=_starship_cfg_right):
+      return _starship_prompt()
+  __xonsh__.env['RIGHT_PROMPT']	= _starship_prompt_right

--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -13,18 +13,14 @@ def _starship_prompt(cfg=None):
         '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
         '--jobs', str(len(__xonsh__.all_jobs))
     ]
-
-    env = {'STARSHIP_CONFIG': cfg} if cfg else {}
-    with __xonsh__.env.swap(env):
+    with __xonsh__.env.swap({'STARSHIP_CONFIG': cfg} if cfg else {}):
         return __xonsh__.subproc_captured_stdout(cmd)
 
         
 _left_cfg  = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_LEFT' , '')
 _left_cfg = Path(_left_cfg).expanduser() if _left_cfg else _left_cfg
-
 if _left_cfg and not _left_cfg.exists():
     print(f"xontrib-prompt-starship: The path doesn't exist: {_left_cfg}", file=sys.stderr)
-
 __xonsh__.env['PROMPT']	= lambda: _starship_prompt(_left_cfg)
 
 

--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -14,10 +14,9 @@ def _starship_prompt(cfg=None):
         '--jobs', str(len(__xonsh__.all_jobs))
     ]
 
-    if cfg:
-        with __xonsh__.env.swap(STARSHIP_CONFIG=cfg):
-            return __xonsh__.subproc_captured_stdout(cmd)
-    return __xonsh__.subproc_captured_stdout(cmd)
+    env = {'STARSHIP_CONFIG': cfg} if cfg else {}
+    with __xonsh__.env.swap(env):
+        return __xonsh__.subproc_captured_stdout(cmd)
 
         
 _left_cfg  = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_LEFT' , '')

--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -16,14 +16,14 @@ def _starship_prompt(cfg=None):
         ])
 
         
-_left_cfg  = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_LEFT' , '')
+_left_cfg  = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_LEFT_CONFIG' , '')
 _left_cfg = Path(_left_cfg).expanduser() if _left_cfg else _left_cfg
 if _left_cfg and not _left_cfg.exists():
     print(f"xontrib-prompt-starship: The path doesn't exist: {_left_cfg}", file=sys.stderr)
 __xonsh__.env['PROMPT']	= lambda: _starship_prompt(_left_cfg)
 
 
-_right_cfg = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_RIGHT', '')
+_right_cfg = __xonsh__.env.get('XONTRIB_PROMPT_STARSHIP_RIGHT_CONFIG', '')
 _right_cfg = Path(_right_cfg ).expanduser() if _right_cfg else _right_cfg 
 if _right_cfg:
     if _right_cfg.exists():


### PR DESCRIPTION
Although the starship prompt by itself doesn't yet support splitting prompts into the Left and Right ones (though there is some [draft PR](https://github.com/starship/starship/pull/2425) that can change that), the awesomeness of xonsh allows us to have both prompts within starship even before they support it — we just need to feed starship a different `$STARSHIP_CONFIG` environment variable for each part