### PR TITLE
Temporary fix for a starship bug not accepting negative return values

### DIFF
--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -13,7 +13,7 @@ def _starship_prompt(cfg=None):
     with __xonsh__.env.swap({'STARSHIP_CONFIG': cfg} if cfg else {}):
         return __xonsh__.subproc_captured_stdout([
             'starship', 'prompt',
-            '--status', str(abs(int( __xonsh__.history[-1].rtn))) if len(__xonsh__.history) > 0 else '0',
+            ('--status=' + str(int( __xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0'),
             '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
             '--jobs', str(len(__xonsh__.all_jobs)),
             '--terminal-width', str(os.get_terminal_size().columns),

--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -13,7 +13,7 @@ def _starship_prompt(cfg=None):
     with __xonsh__.env.swap({'STARSHIP_CONFIG': cfg} if cfg else {}):
         return __xonsh__.subproc_captured_stdout([
             'starship', 'prompt',
-            '--status', str(int( __xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0',
+            '--status', str(abs(int( __xonsh__.history[-1].rtn))) if len(__xonsh__.history) > 0 else '0',
             '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
             '--jobs', str(len(__xonsh__.all_jobs)),
             '--terminal-width', str(os.get_terminal_size().columns),


### PR DESCRIPTION
I've been bugged a lot by weird starship error messages when I abort some commands, then finally found out that for some reason starthip can't accept negative values as return status numbers
I've filed a bug upstream https://github.com/starship/starship/issues/4980, but in the meantime am using this commit to always return positive command return status values
