### PR TITLE
fix: suppress spurious job indicator after command not found

### DIFF
--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -15,7 +15,7 @@ def _starship_prompt(cfg: str) -> None:
             'starship', 'prompt',
             ('--status=' + (str(int( __xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0')),
             '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
-            '--jobs', str(len(__xonsh__.all_jobs)),
+            '--jobs', str(len([j for j in __xonsh__.all_jobs.values() if j['pids']])),
             '--terminal-width', str(os.get_terminal_size().columns),
         ])
 


### PR DESCRIPTION
Whenever the user enters an invalid command into xonsh, the next jobs list seen by xontrib-prompt-starship contains a spurious job with no pids. This in turn leads starship to erroneously report a running job, e.g. with a ✦ character.

This commit fixes the issue by skipping pidless jobs when counting jobs to feed to starship.