### PR TITLE
fix: handle None rtn and ts[1] in history entries after KeyboardInter…

### DIFF
--- a/xontrib/prompt_starship.py
+++ b/xontrib/prompt_starship.py
@@ -10,11 +10,20 @@ __xonsh__.env['STARSHIP_SESSION_KEY'] = __xonsh__.subproc_captured_stdout(['star
 
 def _starship_prompt(cfg: str) -> None:
     import os
+    hist = __xonsh__.history
+    if len(hist) > 0:
+        rtn = hist[-1].rtn
+        status = str(int(rtn)) if rtn is not None else '0'
+        ts = hist[-1].ts
+        duration = str(int((ts[1] - ts[0]) * 1000)) if ts[1] is not None else '0'
+    else:
+        status = '0'
+        duration = '0'
     with __xonsh__.env.swap({'STARSHIP_CONFIG': cfg} if cfg else {}):
         return __xonsh__.subproc_captured_stdout([
             'starship', 'prompt',
-            ('--status=' + (str(int( __xonsh__.history[-1].rtn)) if len(__xonsh__.history) > 0 else '0')),
-            '--cmd-duration' , str(int((__xonsh__.history[-1].ts[1] - __xonsh__.history[-1].ts[0])*1000)) if len(__xonsh__.history) > 0 else '0',
+            '--status=' + status,
+            '--cmd-duration', duration,
             '--jobs', str(len([j for j in __xonsh__.all_jobs.values() if j['pids']])),
             '--terminal-width', str(os.get_terminal_size().columns),
         ])


### PR DESCRIPTION
…rupt

xonsh's BaseShell.default() resets hist.last_cmd_rtn to None at the start of each command cycle (base_shell.py:421) and only sets it to a concrete value when a subprocess pipeline completes via CommandPipeline._apply_to_history(), or via the except/finally guards in run_compiled_code().

When the user interrupts input with Ctrl+C (KeyboardInterrupt), xonsh re-raises the exception immediately (base_shell.py:454-455) and the finally block in default() still calls _append_history() with hist.last_cmd_rtn still None (base_shell.py:495). The resulting HistoryEntry is committed to the sqlite/json backend with rtn=None and ts[1]=None (end timestamp never written because ts1 was never assigned).

The prompt field lambda then crashes on the next prompt render:

    str(int(__xonsh__.history[-1].rtn))
    TypeError: int() argument must be a string, a bytes-like object
    or a real number, not 'NoneType'

This is not version-specific: the None-rtn path exists in every xonsh release that has the last_cmd_rtn reset guard (introduced to fix #4912). Any xonsh version with sqlite or json history backend is affected.

Fix: extract rtn and ts[1] once, guard both with an explicit None check before calling int(), and fall back to '0' in either case. This matches the semantics starship expects: exit code 0 and duration 0ms for an interrupted (non-executed) command.